### PR TITLE
feat(game): add Timescale (Game tab slider; scales BattleGameTime::Tick)

### DIFF
--- a/BA-Cheeto.vcxproj
+++ b/BA-Cheeto.vcxproj
@@ -36,6 +36,7 @@
     <ClInclude Include="src\user\cheat\features\combat\OneHitKill.h" />
     <ClInclude Include="src\user\cheat\features\debug\Debug.h" />
     <ClInclude Include="src\user\cheat\features\game\InstantWin.h" />
+  <ClInclude Include="src\user\cheat\features\game\Timescale.h" />
     <ClInclude Include="src\user\cheat\features\hooks\BattleEntityHook.h" />
     <ClInclude Include="src\user\cheat\features\player\GodMode.h" />
     <ClInclude Include="src\user\cheat\features\player\NoCost.h" />
@@ -90,6 +91,7 @@
     <ClCompile Include="src\user\cheat\features\combat\OneHitKill.cpp" />
     <ClCompile Include="src\user\cheat\features\debug\Debug.cpp" />
     <ClCompile Include="src\user\cheat\features\game\InstantWin.cpp" />
+  <ClCompile Include="src\user\cheat\features\game\Timescale.cpp" />
     <ClCompile Include="src\user\cheat\features\hooks\BattleEntityHook.cpp" />
     <ClCompile Include="src\user\cheat\features\player\GodMode.cpp" />
     <ClCompile Include="src\user\cheat\features\player\NoCost.cpp" />

--- a/src/user/cheat/cheat.cpp
+++ b/src/user/cheat/cheat.cpp
@@ -14,6 +14,7 @@
 
 #include "features/game/InstantWin.h"
 #include "features/game/SkipBattleSummary.h"
+#include "features/game/Timescale.h"
 
 #include "features/hooks/BattleEntityHook.h"
 
@@ -31,7 +32,8 @@ void cheat::init()
         features::DumbEnemies,
         features::OneHitKill,
         features::InstantWin,
-        features::SkipBattleSummary,
+    features::SkipBattleSummary,
+    features::Timescale,
 
         // Hooks
         features::BattleEntityHook

--- a/src/user/cheat/features/game/Timescale.cpp
+++ b/src/user/cheat/features/game/Timescale.cpp
@@ -1,3 +1,2 @@
-// Consolidated definitions in header; this TU ensures the header is compiled with PCH
 #include "pch.h"
 #include "Timescale.h"

--- a/src/user/cheat/features/game/Timescale.cpp
+++ b/src/user/cheat/features/game/Timescale.cpp
@@ -1,0 +1,3 @@
+// Consolidated definitions in header; this TU ensures the header is compiled with PCH
+#include "pch.h"
+#include "Timescale.h"

--- a/src/user/cheat/features/game/Timescale.h
+++ b/src/user/cheat/features/game/Timescale.h
@@ -1,0 +1,60 @@
+// Timescale feature — declaration and inline methods
+#pragma once
+#include "user/cheat/feature_base.h"
+#include "appdata/types.h"
+#include "memory/hook_manager.h"
+#include <algorithm>
+
+namespace cheat::features
+{
+	// Speeds up battle logic by scaling BattleGameTime::Tick.
+	class Timescale : public FeatureBase
+	{
+		DECL_SINGLETON(Timescale)
+
+	public:
+		inline Timescale()
+			: FeatureBase("Timescale", "Speed up battle by scaling logic time per tick", FeatureSection::Game)
+		{
+			HookManager::install(BattleGameTime::Tick(), hBattleGameTime_Tick);
+		}
+
+		inline void draw() override
+		{
+			ImGui::SliderFloat("Scale (x)", &m_scale, 0.1f, 10.0f, "%.2fx");
+			ImGui::SameLine();
+			if (ImGui::Button("Reset")) m_scale = 1.0f;
+			ImGui::TextDisabled("Affects battle logic tick; 2.0x ~ twice as fast");
+		}
+
+		float getScale() const { return m_scale; }
+
+	private:
+		inline static void hBattleGameTime_Tick(BattleGameTime* _this)
+		{
+			if (!s_instance->isEnabled())
+			{
+				CALL_ORIGINAL(hBattleGameTime_Tick, _this);
+				return;
+			}
+
+			const float scale = std::clamp(s_instance->m_scale, 0.1f, 10.0f);
+
+			const float oldLogicSecPerFrame = _this->LogicSecondPerFrame();
+			const int32_t oldCurrentFrame = _this->CurrentFrame();
+
+			_this->LogicSecondPerFrame(oldLogicSecPerFrame / scale);
+
+			CALL_ORIGINAL(hBattleGameTime_Tick, _this);
+
+			_this->LogicSecondPerFrame(oldLogicSecPerFrame);
+
+			if (_this->CurrentFrame() < oldCurrentFrame)
+			{
+				_this->CurrentFrame(oldCurrentFrame);
+			}
+		}
+
+		float m_scale = 1.0f;
+	};
+}

--- a/src/user/cheat/features/game/Timescale.h
+++ b/src/user/cheat/features/game/Timescale.h
@@ -1,4 +1,3 @@
-// Timescale feature — declaration and inline methods
 #pragma once
 #include "user/cheat/feature_base.h"
 #include "appdata/types.h"


### PR DESCRIPTION
- Adds “Timescale” under Game tab with 0.1x–10x slider + Reset
- Hooks BattleGameTime::Tick, temporarily scales LogicSecondPerFrame, restores after call
- Default 1.0x; disabled = no effect
- Files touched: Timescale.h, Timescale.cpp, cheat.cpp, BA-Cheeto.vcxproj

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/26f41cf9-c98e-4f9b-abc0-a5366352f364" />

<img width="1917" height="1078" alt="image" src="https://github.com/user-attachments/assets/e32d317c-47b5-4018-bf88-7ba36101328d" />
