### PR TITLE
Feature/config

### DIFF
--- a/BA-Cheeto.vcxproj
+++ b/BA-Cheeto.vcxproj
@@ -41,6 +41,7 @@
     <ClInclude Include="src\user\cheat\features\player\NoCost.h" />
     <ClInclude Include="src\user\main.h" />
     <ClInclude Include="src\utils\dx_utils.h" />
+  <ClInclude Include="src\utils\config_manager.h" />
     <ClInclude Include="src\utils\logger.h" />
     <ClInclude Include="src\utils\singleton.h" />
     <ClInclude Include="vendor\imgui\backends\imgui_impl_dx11.h" />
@@ -96,6 +97,7 @@
     <ClCompile Include="src\user\main.cpp" />
     <ClCompile Include="src\utils\dx_utils.cpp" />
     <ClCompile Include="src\utils\logger.cpp" />
+  <ClCompile Include="src\utils\config_manager.cpp" />
     <ClCompile Include="vendor\imgui\backends\imgui_impl_dx11.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
@@ -223,6 +225,7 @@
       <EnableUAC>false</EnableUAC>
       <AdditionalDependencies>libMinHook.x64.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ProjectDir)vendor\minhook\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+  <IgnoreSpecificDefaultLibraries>LIBCMT;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
     </Link>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/core/pipe/pipe_manager.cpp
+++ b/src/core/pipe/pipe_manager.cpp
@@ -159,7 +159,8 @@ void PipeManager::handleClient(HANDLE hPipe)
                 // Send acknowledgment back to client
                 std::string response = "OK: " + feature + ":" + (enabled ? "enabled" : "disabled");
                 DWORD bytesWritten;
-                WriteFile(hPipe, response.c_str(), response.length(), &bytesWritten, nullptr);
+                const DWORD toWrite = static_cast<DWORD>(response.size());
+                WriteFile(hPipe, response.c_str(), toWrite, &bytesWritten, nullptr);
                 FlushFileBuffers(hPipe);
             }
             else
@@ -167,7 +168,8 @@ void PipeManager::handleClient(HANDLE hPipe)
                 LOG_ERROR("Unknown command: '{}'", cmd.c_str());
                 std::string response = "ERROR: Unknown command";
                 DWORD bytesWritten;
-                WriteFile(hPipe, response.c_str(), response.length(), &bytesWritten, nullptr);
+                const DWORD toWrite = static_cast<DWORD>(response.size());
+                WriteFile(hPipe, response.c_str(), toWrite, &bytesWritten, nullptr);
                 FlushFileBuffers(hPipe);
             }
         }
@@ -176,7 +178,8 @@ void PipeManager::handleClient(HANDLE hPipe)
             LOG_ERROR("Invalid message format: '{}'", message.c_str());
             std::string response = "ERROR: Invalid format";
             DWORD bytesWritten;
-            WriteFile(hPipe, response.c_str(), response.length(), &bytesWritten, nullptr);
+            const DWORD toWrite = static_cast<DWORD>(response.size());
+            WriteFile(hPipe, response.c_str(), toWrite, &bytesWritten, nullptr);
             FlushFileBuffers(hPipe);
         }
     }

--- a/src/ui/gui.cpp
+++ b/src/ui/gui.cpp
@@ -81,17 +81,17 @@ void GUI::renderMainMenuBar()
         if (fps >= 60.0f)
         {
             ImGui::SameLine();
-            ImGui::TextColored(ImVec4(0.2f, 0.8f, 0.2f, 1.0f), "●");
+            ImGui::TextColored(ImVec4(0.2f, 0.8f, 0.2f, 1.0f), "o");
         }
         else if (fps >= 30.0f)
         {
             ImGui::SameLine();
-            ImGui::TextColored(ImVec4(0.8f, 0.8f, 0.2f, 1.0f), "●");
+            ImGui::TextColored(ImVec4(0.8f, 0.8f, 0.2f, 1.0f), "o");
         }
         else
         {
             ImGui::SameLine();
-            ImGui::TextColored(ImVec4(0.8f, 0.2f, 0.2f, 1.0f), "●");
+            ImGui::TextColored(ImVec4(0.8f, 0.2f, 0.2f, 1.0f), "o");
         }
 
         // Controls hint

--- a/src/user/cheat/feature_manager.cpp
+++ b/src/user/cheat/feature_manager.cpp
@@ -1,5 +1,6 @@
 ﻿#include "pch.h"
 #include "feature_manager.h"
+#include "utils/config_manager.h"
 
 namespace cheat
 {
@@ -18,12 +19,17 @@ namespace cheat
 
     void FeatureManager::init()
     {
-        LOG_INFO("Initializing {} features...", m_features.size());
+    LOG_INFO("Initializing {} features...", m_features.size());
+    ConfigManager::getInstance().load();
 
         for (const auto& feature : m_features)
         {
             try
             {
+                // apply persisted enabled state
+                const bool persisted = ConfigManager::getInstance().getFeatureEnabled(getSectionName(feature->getSection()), feature->getName(), false);
+                feature->setEnabled(persisted);
+
                 feature->init();
                 LOG_INFO("Feature '{}' initialized successfully", feature->getName().c_str());
             }
@@ -59,6 +65,8 @@ namespace cheat
                         if (ImGui::Checkbox(feature->getName().c_str(), &enabled))
                         {
                             feature->setEnabled(enabled);
+                            ConfigManager::getInstance().setFeatureEnabled(getSectionName(feature->getSection()), feature->getName(), enabled);
+                            ConfigManager::getInstance().save();
                         }
 
                         if (!feature->getDescription().empty())

--- a/src/user/cheat/features/game/Timescale.h
+++ b/src/user/cheat/features/game/Timescale.h
@@ -1,0 +1,80 @@
+#pragma once
+#include "user/cheat/feature_base.h"
+#include "appdata/types.h"
+#include "memory/hook_manager.h"
+#include <algorithm>
+#include "utils/config_manager.h"
+
+// intellisense shut up please
+#ifdef __INTELLISENSE__
+#ifndef CALL_ORIGINAL
+#define CALL_ORIGINAL(...) ((void)0)
+#endif
+#endif
+
+namespace cheat::features
+{
+	// Speeds up battle logic by scaling BattleGameTime::Tick.
+	class Timescale : public FeatureBase
+	{
+		DECL_SINGLETON(Timescale)
+
+	public:
+		inline Timescale()
+			: FeatureBase("Timescale", "Speed up battle by scaling logic time per tick", FeatureSection::Game)
+		{
+#ifndef __INTELLISENSE__
+			HookManager::install(BattleGameTime::Tick(), hBattleGameTime_Tick);
+#endif
+		}
+
+		inline void draw() override
+		{
+			float prev = m_scale;
+			ImGui::SliderFloat("Scale (x)", &m_scale, 0.1f, 10.0f, "%.2fx");
+			ImGui::SameLine();
+			if (ImGui::Button("Reset")) m_scale = 1.0f;
+			ImGui::TextDisabled("Affects battle logic tick; 2.0x ~ twice as fast");
+
+			if (m_scale != prev) {
+				ConfigManager::getInstance().setFeatureValue("Game", getName(), "scale", m_scale);
+				ConfigManager::getInstance().save();
+			}
+		}
+
+		float getScale() const { return m_scale; }
+
+		inline void init() override
+		{
+			m_scale = ConfigManager::getInstance().getFeatureValue<float>("Game", getName(), "scale", 1.0f);
+		}
+
+	private:
+		inline static void hBattleGameTime_Tick(BattleGameTime* _this)
+		{
+			if (!s_instance->isEnabled())
+			{
+				CALL_ORIGINAL(hBattleGameTime_Tick, _this);
+				return;
+			}
+
+			const float scale = std::clamp(s_instance->m_scale, 0.1f, 10.0f);
+
+			const float oldLogicSecPerFrame = _this->LogicSecondPerFrame();
+			const int32_t oldCurrentFrame = _this->CurrentFrame();
+
+			_this->LogicSecondPerFrame(oldLogicSecPerFrame / scale);
+
+			CALL_ORIGINAL(hBattleGameTime_Tick, _this);
+
+			_this->LogicSecondPerFrame(oldLogicSecPerFrame);
+
+			if (_this->CurrentFrame() < oldCurrentFrame)
+			{
+				_this->CurrentFrame(oldCurrentFrame);
+			}
+		}
+
+		float m_scale = 1.0f;
+	};
+}

--- a/src/user/cheat/features/game/Timescale.h
+++ b/src/user/cheat/features/game/Timescale.h
@@ -3,6 +3,7 @@
 #include "appdata/types.h"
 #include "memory/hook_manager.h"
 #include <algorithm>
+#include "utils/config_manager.h"
 
 namespace cheat::features
 {
@@ -18,12 +19,24 @@ namespace cheat::features
 			HookManager::install(BattleGameTime::Tick(), hBattleGameTime_Tick);
 		}
 
+		inline void init() override
+		{
+			m_scale = ConfigManager::getInstance().getFeatureValue<float>("Game", getName(), "scale", 1.0f);
+		}
+
 		inline void draw() override
 		{
+			float prev = m_scale;
 			ImGui::SliderFloat("Scale (x)", &m_scale, 0.1f, 10.0f, "%.2fx");
 			ImGui::SameLine();
 			if (ImGui::Button("Reset")) m_scale = 1.0f;
 			ImGui::TextDisabled("Affects battle logic tick; 2.0x ~ twice as fast");
+
+			if (m_scale != prev)
+			{
+				ConfigManager::getInstance().setFeatureValue("Game", getName(), "scale", m_scale);
+				ConfigManager::getInstance().save();
+			}
 		}
 
 		float getScale() const { return m_scale; }

--- a/src/user/cheat/features/player/PlayerStats.h
+++ b/src/user/cheat/features/player/PlayerStats.h
@@ -1,5 +1,6 @@
 ﻿#pragma once
 #include "user/cheat/feature_base.h"
+#include "utils/config_manager.h"
 
 struct BasisPoint;
 
@@ -12,11 +13,13 @@ namespace cheat::features
     public:
         PlayerStats();
 
+    void init() override;
         void draw() override;
 
     private:
         std::unordered_map<StatType_Enum, int> m_statValues;
         std::string m_searchFilter;
+    void saveStatsToConfig();
 
         std::vector<StatType_Enum> getFilteredStats() const;
         void applyStats(BattleEntityStat* entityStat, BattleEntity* battleEntity) const;

--- a/src/utils/config_manager.cpp
+++ b/src/utils/config_manager.cpp
@@ -1,0 +1,96 @@
+#include "pch.h"
+#include "config_manager.h"
+#include "utils/logger.h"
+
+ConfigManager& ConfigManager::getInstance() {
+    static ConfigManager instance;
+    return instance;
+}
+
+std::string ConfigManager::configPath() const {
+    char* appData = nullptr;
+    size_t len = 0;
+    _dupenv_s(&appData, &len, "APPDATA");
+    std::filesystem::path base = appData ? appData : ".";
+    if (appData) free(appData);
+
+    std::filesystem::path dir = base / "Cunny";
+    std::error_code ec;
+    if (!std::filesystem::exists(dir, ec)) {
+        std::filesystem::create_directories(dir, ec);
+        if (ec) LOG_ERROR("Failed to create config directory: {}", ec.message().c_str());
+    }
+    return (dir / "config.json").string();
+}
+
+bool ConfigManager::load() {
+    const auto path = configPath();
+    std::ifstream f(path);
+    if (!f.good()) {
+        m_data = nlohmann::json{ {"version", 1}, {"features", nlohmann::json::object()} };
+        return true;
+    }
+    try {
+        f >> m_data;
+        if (!m_data.contains("features")) m_data["features"] = nlohmann::json::object();
+        return true;
+    } catch (const std::exception& e) {
+        LOG_ERROR("Failed to parse config: {}", e.what());
+        m_data = nlohmann::json{ {"version", 1}, {"features", nlohmann::json::object()} };
+        return false;
+    }
+}
+
+bool ConfigManager::save() {
+    const auto path = configPath();
+    try {
+        std::ofstream f(path, std::ios::trunc);
+        f << m_data.dump(2);
+        return true;
+    } catch (const std::exception& e) {
+        LOG_ERROR("Failed to save config: {}", e.what());
+        return false;
+    }
+}
+
+const nlohmann::json* ConfigManager::getFeatureNodeConst(const std::string& section, const std::string& name) const {
+    auto itF = m_data.find("features");
+    if (itF == m_data.end() || !itF->is_object()) return nullptr;
+    auto itS = itF->find(section);
+    if (itS == itF->end() || !itS->is_object()) return nullptr;
+    auto itN = itS->find(name);
+    if (itN == itS->end() || !itN->is_object()) return nullptr;
+    return &*itN;
+}
+
+nlohmann::json* ConfigManager::getFeatureNode(const std::string& section, const std::string& name) {
+    auto itF = m_data.find("features");
+    if (itF == m_data.end() || !itF->is_object()) return nullptr;
+    auto itS = itF->find(section);
+    if (itS == itF->end() || !itS->is_object()) return nullptr;
+    auto itN = itS->find(name);
+    if (itN == itS->end() || !itN->is_object()) return nullptr;
+    return &*itN;
+}
+
+nlohmann::json& ConfigManager::getOrCreateFeatureNode(const std::string& section, const std::string& name) {
+    if (!m_data.contains("features") || !m_data["features"].is_object()) m_data["features"] = nlohmann::json::object();
+    auto& features = m_data["features"];
+    if (!features.contains(section) || !features[section].is_object()) features[section] = nlohmann::json::object();
+    auto& sec = features[section];
+    if (!sec.contains(name) || !sec[name].is_object()) sec[name] = nlohmann::json::object();
+    return sec[name];
+}
+
+bool ConfigManager::getFeatureEnabled(const std::string& section, const std::string& name, bool def) const {
+    const auto* node = getFeatureNodeConst(section, name);
+    if (!node) return def;
+    auto it = node->find("enabled");
+    if (it == node->end()) return def;
+    try { return it->get<bool>(); } catch (...) { return def; }
+}
+
+void ConfigManager::setFeatureEnabled(const std::string& section, const std::string& name, bool enabled) {
+    auto& node = getOrCreateFeatureNode(section, name);
+    node["enabled"] = enabled;
+}

--- a/src/utils/config_manager.h
+++ b/src/utils/config_manager.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <filesystem>
+#include <fstream>
+#include <Windows.h>
+#include <nlohmann/json.hpp>
+
+class ConfigManager {
+public:
+    static ConfigManager& getInstance();
+
+    bool load();
+    bool save();
+
+    // feature path helpers
+    bool getFeatureEnabled(const std::string& section, const std::string& name, bool def = false) const;
+    void setFeatureEnabled(const std::string& section, const std::string& name, bool enabled);
+
+    template <typename T>
+    T getFeatureValue(const std::string& section, const std::string& name, const std::string& key, const T& def) const {
+        const nlohmann::json* node = getFeatureNodeConst(section, name);
+        if (!node) return def;
+        const auto it = node->find(key);
+        if (it == node->end()) return def;
+        try { return it->get<T>(); } catch (...) { return def; }
+    }
+
+    template <typename T>
+    void setFeatureValue(const std::string& section, const std::string& name, const std::string& key, const T& value) {
+        auto& node = getOrCreateFeatureNode(section, name);
+        node[key] = value;
+    }
+
+    const nlohmann::json& data() const { return m_data; }
+
+private:
+    ConfigManager() = default;
+
+    std::string configPath() const;
+    nlohmann::json* getFeatureNode(const std::string& section, const std::string& name);
+    const nlohmann::json* getFeatureNodeConst(const std::string& section, const std::string& name) const;
+    nlohmann::json& getOrCreateFeatureNode(const std::string& section, const std::string& name);
+
+    nlohmann::json m_data;
+};


### PR DESCRIPTION
Adds a lightweight JSON ConfigManager to persist feature state and values across runs.

Persists:
- Feature enabled/disabled (all features)
- Timescale multiplier (Game > Timescale)
- Player Stats inputs (per-stat values)

Intergrations:
- FeatureManager loads config on init and saves on toggle changes
- Timescale loads “scale” on init, saves on slider change/reset
- Player Stats loads/saves inputs per stat on change/reset

Config path: %AppData%\Cunny\config.json (Windows)
Creates config dir/file if missing
Ignores unknown keys
On corrupt JSON, logs and continues with defaults